### PR TITLE
Fixed Dr. Witmer's bug

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -199,7 +199,9 @@ class Callback(TemplateView):
 
         # Create a user in our db if none exists
         if not userInfo:
-            names = oathUserInfo.get("name").split()
+            names = oathUserInfo.get("name", "").split()
+            if not names:
+                names=[""]
             userInfo, _ = UsersAPIView.createUser(
                 {
                     "email": oathUserInfo["email"],


### PR DESCRIPTION
Fixed the following bug (I think) by handleing login cases where the user's name does not exist.

```
AttributeError at /callback/
'NoneType' object has no attribute 'split'
Request Method:	GET
Request URL:	http://quayside.app/callback/?code=d29fc8b5fd9917a2f7ac&state=%2F
Django Version:	5.0.1
Exception Type:	AttributeError
Exception Value:	
'NoneType' object has no attribute 'split'
Exception Location:	/app/app/views.py, line 202, in get
Raised during:	app.views.Callback
Python Executable:	/usr/local/bin/python
Python Version:	3.12.2
Python Path:	
['/app',
 '/usr/local/lib/python312.zip',
 '/usr/local/lib/python3.12',
 '/usr/local/lib/python3.12/lib-dynload',
 '/usr/local/lib/python3.12/site-packages']
Server time:	Mon, 18 Mar 2024 04:02:41 +0000
Traceback Switch to copy-and-paste view
/usr/local/lib/python3.12/site-packages/django/core/handlers/exception.py, line 55, in inner
                response = get_response(request)
                               ^^^^^^^^^^^^^^^^^^^^^
…
Local vars
/usr/local/lib/python3.12/site-packages/django/core/handlers/base.py, line 197, in _get_response
                response = wrapped_callback(request, *callback_args, **callback_kwargs)
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
…
Local vars
/usr/local/lib/python3.12/site-packages/django/views/generic/base.py, line 104, in view
            return self.dispatch(request, *args, **kwargs)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
…
Local vars
/usr/local/lib/python3.12/site-packages/django/views/generic/base.py, line 143, in dispatch
        return handler(request, *args, **kwargs)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
…
Local vars
/app/app/views.py, line 202, in get
            names = oathUserInfo.get("name").split()
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
…
Local vars
```