### PR TITLE
Show Qpa duck on every page

### DIFF
--- a/.claude/skills/screenshot-pr/SKILL.md
+++ b/.claude/skills/screenshot-pr/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: screenshot-pr
+description: Take Playwright screenshots of key UI pages and attach them to the current PR as a comment
+---
+
+# Screenshot PR
+
+Take screenshots of the running app using Playwright and post them as a comment on the current open PR for this branch.
+
+## Steps
+
+1. **Authenticate** — navigate to `http://localhost:8000/dev-login/?next=/` to set the session cookie.
+
+2. **Identify pages to screenshot** — use the pages provided as arguments (e.g. `/screenshot-pr /projects/123`). If no pages are given, screenshot the following defaults:
+   - `/` — home / dashboard
+   - Any page that is directly relevant to the current branch's changes (infer from the branch name or recent commits)
+
+3. **Take screenshots** — for each page:
+   - Navigate to `http://localhost:8000{path}`
+   - Take a full-page screenshot and save it to `.playwright-mcp/`
+   - Note the filename
+
+4. **Upload images to the PR** — GitHub PR comments don't accept file attachments via `gh` CLI directly. Instead:
+   - Use `gh pr view --json number` to get the PR number
+   - For each screenshot, encode it as a base64 data URI or upload it using the GitHub API:
+     ```
+     gh api repos/{owner}/{repo}/issues/{pr_number}/comments \
+       --method POST \
+       --field body="## UI Screenshots\n\n![screenshot]({image_url})"
+     ```
+   - Since GitHub doesn't host arbitrary images via the API, the practical approach is to upload each image as a file to the PR's associated commit using the GitHub API, or post the raw screenshots inline by uploading them to the repo temporarily.
+
+   **Preferred approach:** Use `gh pr comment` with the screenshots embedded as markdown image references. Because GitHub auto-hosts images dragged into comments but not via CLI, instead:
+   - Post a PR comment with the screenshots using the GitHub CLI:
+     ```
+     gh pr comment --body "$(cat <<'EOF'
+     ## UI Screenshots
+     <!-- screenshots attached below -->
+     EOF
+     )"
+     ```
+   - Then upload each screenshot file to the GitHub PR using the API to create a gist, or attach via the issue comment upload endpoint.
+
+   **Simplest working approach:**
+   - Upload each image to a new GitHub Gist (public), get the raw URL, and embed in the PR comment.
+     ```
+     gh gist create --public .playwright-mcp/{filename}.png --desc "UI screenshot for PR"
+     ```
+   - Get the raw gist URL and embed it in the PR comment body.
+
+5. **Post the PR comment** with all screenshots embedded as markdown images:
+   ```
+   gh pr comment --body "## UI Screenshots\n\n**Home page:**\n![home](https://...)"
+   ```
+
+6. **Show the screenshots** to the user inline in the conversation so they can see them without leaving the terminal.
+
+## Notes
+
+- The dev server must be running at `http://localhost:8000` for this to work.
+- The `devLogin` endpoint only works when `DEBUG=True`.
+- Screenshots are saved locally to `.playwright-mcp/` regardless of whether the PR upload succeeds.
+- If no PR exists for the current branch yet, say so and show the screenshots in the conversation only.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,13 +55,12 @@ jobs:
             GITHUB_API_URL_email=https://api.github.com/user/emails
             GITHUB_API_URL_user=https://api.github.com/user
             GOOGLE_API_URL_userprofile=https://www.googleapis.com/oauth2/v2/userinfo
-          secrets: |
-            MONGO_USERNAME=MONGO_USERNAME:latest
-            MONGO_PASSWORD=MONGO_PASSWORD:latest
-            CHATGPT_API_KEY=CHATGPT_API_KEY:latest
-            GITHUB_CLIENT_ID=GITHUB_CLIENT_ID:latest
-            GITHUB_CLIENT_SECRET=GITHUB_CLIENT_SECRET:latest
-            GOOGLE_CLIENT_ID=GOOGLE_CLIENT_ID:latest
-            GOOGLE_CLIENT_SECRET=GOOGLE_CLIENT_SECRET:latest
-            API_SECRET=API_SECRET:latest
-            REDIRECT_URI=REDIRECT_URI:latest
+            MONGO_USERNAME=${{ secrets.MONGO_USERNAME }}
+            MONGO_PASSWORD=${{ secrets.MONGO_PASSWORD }}
+            CHATGPT_API_KEY=${{ secrets.CHATGPT_API_KEY }}
+            GITHUB_CLIENT_ID=${{ secrets.GH_CLIENT_ID }}
+            GITHUB_CLIENT_SECRET=${{ secrets.GH_CLIENT_SECRET }}
+            GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}
+            GOOGLE_CLIENT_SECRET=${{ secrets.GOOGLE_CLIENT_SECRET }}
+            API_SECRET=${{ secrets.API_SECRET }}
+            REDIRECT_URI=${{ secrets.REDIRECT_URI }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules/
 env
 launch.json
 .idea
+.qodo

--- a/.mcp.json
+++ b/.mcp.json
@@ -28,7 +28,7 @@
     "playwright": {
       "type": "stdio",
       "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+      "args": ["@playwright/mcp@latest", "--browser", "chromium"]
     },
     "code-graph": {
       "type": "stdio",

--- a/api/views/v1/generatedTasks.py
+++ b/api/views/v1/generatedTasks.py
@@ -79,7 +79,7 @@ class GeneratedTasksAPIView(APIView):
                     "role": "system",
                     "content": """You are an assistant for quayside.app, a project management team. 
                     You are given as input a project or task that a single person or a team 
-                    wants to take on. Divide the task into less than 5 subtasks and list them 
+                    wants to take on. Divide the task into as many subtasks as are needed and list them 
                     hierarchically in the format where task 1 has subtasks 1.1, 1.2,...
                     and task 2 has subtasks 2.1, 2.2, 2.3,... and so forth and allow for subtasks to 
                     have their own hierarcy in the format of 1.1.1, 1.1.2, 1.13,... and so forth. For each subtask without it's own hierarcy, 

--- a/app/static/app/js/tree.js
+++ b/app/static/app/js/tree.js
@@ -182,10 +182,16 @@ function Trees(dataList, {
 
         node.append("rect")
             .attr("fill", d => fill(d.data, d))
-            .attr("rx", 5)
-            .attr("width",  nodeWidth)// .attr("width",  `${maxTextLength*0.85}em`)
+            .attr("rx", 4)
+            .attr("width",  nodeWidth)
             .attr("height", nodeHeight)
             .attr("y", -nodeHeight / 2)
+            .attr("stroke", "rgba(64,196,255,0.35)")
+            .attr("stroke-width", 1)
+            .style("filter", "drop-shadow(0px 0px 5px rgba(64,196,255,0.2)) drop-shadow(0px 2px 6px rgba(0,0,0,0.6))")
+            .style("cursor", "pointer")
+            .on("mouseover", function() { d3.select(this).style("filter", "drop-shadow(0px 0px 10px rgba(64,196,255,0.5)) drop-shadow(0px 2px 8px rgba(0,0,0,0.7))"); })
+            .on("mouseout",  function() { d3.select(this).style("filter", "drop-shadow(0px 0px 5px rgba(64,196,255,0.2)) drop-shadow(0px 2px 6px rgba(0,0,0,0.6))"); })
 
         // "+"" Icon
         const iconGroup = node.append("g")

--- a/app/urls.py
+++ b/app/urls.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.urls import path
 
 from app import views
@@ -52,3 +53,6 @@ urlpatterns = [
     path("callback/", views.Callback.as_view(), name="callback"),
     path('redirect/', views.redirectOffSite,name='offsite-redirect'),
 ]
+
+if settings.DEBUG:
+    urlpatterns += [path('dev-login/', views.devLogin, name='dev-login')]

--- a/app/views.py
+++ b/app/views.py
@@ -7,12 +7,14 @@ from oauthlib.oauth2 import WebApplicationClient as WAC
 from rest_framework import status
 
 # django imports
+from django.conf import settings
 from django.shortcuts import render, redirect
-from django.http import HttpResponseRedirect, HttpResponseServerError
+from django.http import Http404, HttpResponseRedirect, HttpResponseServerError
 from django.views.generic.base import TemplateView
 
 # api imports
 from api.decorators import apiKeyRequired
+from api.models import User
 from api.utils import (
     decryptApiKey,
     createEncodedApiKey,
@@ -557,6 +559,32 @@ def marketplaceView(request):
     return render(request, "marketplace.html", {})
 
 
+
+
+def devLogin(request):
+    """
+    DEV ONLY (DEBUG=True): sets the apiToken cookie for the first user in the DB so
+    automated tools (e.g. Playwright) can browse authenticated pages without OAuth.
+    """
+    if not settings.DEBUG:
+        raise Http404
+
+    user = User.objects.order_by("id").first()
+    if not user or not user.apiKey:
+        return HttpResponseServerError("No user with an API key found in the database.")
+
+    apiToken = decryptApiKey(user.apiKey)
+    if not apiToken:
+        return HttpResponseServerError("Failed to decrypt API key.")
+
+    # Restrict redirect to local paths only — prevent open redirect
+    next_url = request.GET.get("next", "/")
+    if not next_url.startswith("/") or next_url.startswith("//"):
+        next_url = "/"
+
+    response = redirect(next_url)
+    response.set_cookie("apiToken", apiToken, httponly=True, samesite="Strict")
+    return response
 
 
 def requestAuth(_request, provider):


### PR DESCRIPTION
## Summary
- Qpa duck (AI assistant) is now persistently visible on all pages, not just project views
- Task tree nodes get a blue glow drop-shadow with hover effect and pointer cursor
- Removed the artificial "less than 5 subtasks" cap from AI task generation

## Production readiness
- Switched from `runserver` to gunicorn in Dockerfile
- Added whitenoise for static file serving + `collectstatic` in Docker build

## Dev tooling
- Added `/dev-login/` endpoint (DEBUG only) for Playwright/automated browser auth without OAuth
  - Route only registered when `DEBUG=True`
  - Open redirect protection: `next` param restricted to local paths
- Added `/screenshot-pr` skill for capturing UI screenshots during review
- Pinned Playwright MCP to chromium

## UI Screenshots

Qpa duck visible bottom-right on all pages:

**Home page**
_(drag `.playwright-mcp/home.png` here)_

**Project graph**
_(drag `.playwright-mcp/project-graph.png` here)_

## Test plan
- [ ] Home page — Qpa duck visible bottom-right
- [ ] Project graph — Qpa duck still visible
- [ ] Project kanban — Qpa duck still visible
- [ ] Hover over task tree nodes — glow effect appears
- [ ] `/dev-login/` returns 404 in production (DEBUG=False)
- [ ] `/dev-login/?next=https://evil.com` redirects to `/` not external URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)