### PR TITLE
Cross-project What's Next on the home page

### DIFF
--- a/api/progress.py
+++ b/api/progress.py
@@ -75,3 +75,30 @@ def next_actions(statuses, tasks, limit=3):
         "in_flight": [brief(task) for task in sorted(in_flight, key=rank)],
         "next_up": [brief(task) for task in sorted(next_pool, key=rank)[:limit]],
     }
+
+
+def cross_project_next(projects, limit=8):
+    """One ranked view of work across every project: what is moving, what to start.
+
+    Projects with tasks in flight come first (you are already working them),
+    then the most active, then alphabetically. Finished and empty projects drop
+    out so the list is only the work that still wants attention.
+    """
+    digests = []
+    for project in projects:
+        actions = next_actions(project["statuses"], project["tasks"])
+        if actions["in_flight"] or actions["next_up"]:
+            digests.append({
+                "id": str(project["id"]),
+                "name": project["name"],
+                "in_flight": actions["in_flight"],
+                "next_up": actions["next_up"],
+            })
+
+    digests.sort(key=lambda digest: (
+        0 if digest["in_flight"] else 1,
+        -len(digest["in_flight"]),
+        (digest["name"] or "").lower(),
+    ))
+
+    return {"projects": digests[:limit], "more": max(0, len(digests) - limit)}

--- a/app/static/app/src/output.css
+++ b/app/static/app/src/output.css
@@ -747,6 +747,10 @@ video {
   margin-bottom: 1rem;
 }
 
+.mb-5 {
+  margin-bottom: 1.25rem;
+}
+
 .ml-1 {
   margin-left: 0.25rem;
 }
@@ -941,8 +945,8 @@ video {
   width: max-content;
 }
 
-.w-screen {
-  width: 100vw;
+.max-w-3xl {
+  max-width: 48rem;
 }
 
 .max-w-sm {
@@ -993,6 +997,10 @@ video {
   align-items: center;
 }
 
+.items-baseline {
+  align-items: baseline;
+}
+
 .justify-start {
   justify-content: flex-start;
 }
@@ -1015,6 +1023,12 @@ video {
 
 .gap-3 {
   gap: 0.75rem;
+}
+
+.space-y-3 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0.75rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0.75rem * var(--tw-space-y-reverse));
 }
 
 .overflow-hidden {
@@ -1300,6 +1314,10 @@ video {
   padding-bottom: 0.5rem;
 }
 
+.pb-24 {
+  padding-bottom: 6rem;
+}
+
 .pb-3 {
   padding-bottom: 0.75rem;
 }
@@ -1340,8 +1358,8 @@ video {
   padding-top: 1.25rem;
 }
 
-.pt-80 {
-  padding-top: 20rem;
+.pt-8 {
+  padding-top: 2rem;
 }
 
 .text-left {
@@ -1364,11 +1382,6 @@ video {
 .text-3xl {
   font-size: 1.875rem;
   line-height: 2.25rem;
-}
-
-.text-4xl {
-  font-size: 2.25rem;
-  line-height: 2.5rem;
 }
 
 .text-5xl {
@@ -1518,6 +1531,11 @@ video {
   background-color: rgb(115 115 115 / var(--tw-bg-opacity));
 }
 
+.hover\:bg-neutral-600:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(82 82 82 / var(--tw-bg-opacity));
+}
+
 .hover\:bg-neutral-700:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(64 64 64 / var(--tw-bg-opacity));
@@ -1555,6 +1573,10 @@ video {
 .hover\:text-neutral-500:hover {
   --tw-text-opacity: 1;
   color: rgb(115 115 115 / var(--tw-text-opacity));
+}
+
+.hover\:underline:hover {
+  text-decoration-line: underline;
 }
 
 @media (min-width: 640px) {
@@ -1627,6 +1649,11 @@ video {
     padding-right: 0px;
   }
 
+  .sm\:px-8 {
+    padding-left: 2rem;
+    padding-right: 2rem;
+  }
+
   .sm\:pl-2 {
     padding-left: 0.5rem;
   }
@@ -1638,6 +1665,11 @@ video {
   .sm\:text-2xl {
     font-size: 1.5rem;
     line-height: 2rem;
+  }
+
+  .sm\:text-3xl {
+    font-size: 1.875rem;
+    line-height: 2.25rem;
   }
 
   .sm\:text-lg {

--- a/app/templates/components/whatsnext_all.html
+++ b/app/templates/components/whatsnext_all.html
@@ -1,0 +1,37 @@
+{% if available %}
+  {% if projects %}
+    <div class="space-y-3">
+      {% for project in projects %}
+        <div class="bg-neutral-800 rounded-lg p-4">
+          <a href="/project/{{ project.id }}/graph/" class="font-semibold sm:text-lg hover:underline">{{ project.name }}</a>
+
+          {% if project.in_flight %}
+            <div class="mt-2">
+              <div class="text-xs uppercase tracking-wide text-neutral-400 mb-1">In flight</div>
+              {% for task in project.in_flight %}
+                <a href="/project/{{ project.id }}/graph/task/{{ task.id }}/" class="block truncate rounded px-2 py-1 hover:bg-neutral-700">{{ task.name }}</a>
+              {% endfor %}
+            </div>
+          {% endif %}
+
+          {% if project.next_up %}
+            <div class="mt-2">
+              <div class="text-xs uppercase tracking-wide text-neutral-400 mb-1">Next up</div>
+              {% for task in project.next_up %}
+                <a href="/project/{{ project.id }}/graph/task/{{ task.id }}/" class="block truncate rounded px-2 py-1 hover:bg-neutral-700">{{ task.name }}</a>
+              {% endfor %}
+            </div>
+          {% endif %}
+        </div>
+      {% endfor %}
+    </div>
+
+    {% if more %}
+      <div class="text-neutral-400 text-sm mt-3">+ {{ more }} more project{{ more|pluralize }} with open work</div>
+    {% endif %}
+  {% else %}
+    <div class="bg-neutral-800 rounded-lg p-4 text-neutral-300">
+      No open work across your projects. Create a project or add tasks to get started.
+    </div>
+  {% endif %}
+{% endif %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,27 +1,23 @@
 {% extends "_base.html" %}
 {% load static %}
+{% load whatsnext %}
 
 {% block content %}
 
-<div class='fixed left-0 pt-80  text-white  w-screen text-center'>
+<div class="text-white overflow-y-auto px-4 sm:px-8 pb-24" style="height:calc(100vh - 3.5rem)">
+  <div class="max-w-3xl mx-auto pt-8">
 
+    <div class="flex items-baseline justify-between mb-1">
+      <h1 class="text-2xl sm:text-3xl font-bold">What's Next</h1>
+      <a href="/?newProjectModal=true">
+        <button class="bg-neutral-700 hover:bg-neutral-600 rounded-lg px-3 py-1 text-sm">New project</button>
+      </a>
+    </div>
+    <p class="text-neutral-300 text-sm mb-5">Across all your projects: what's in flight, and what to pick up next.</p>
 
-  <div class='  text-4xl md:text-7xl font-bold '>
-    quayside.app
+    {% whats_next_all userID %}
+
   </div>
-
-  <div class=' md:text-3xl mt-3'>
-    Ignite Collaborative Productivity
-  </div>
-
-  <div class=' text-sm md:text-xl  mt-3'>
-    <a href='/?newProjectModal=true' >
-      <button class='bg-neutral-700 rounded-lg mx-2 px-2 py-1'>
-        Create a project to get started...
-      </button>
-    </a>
 </div>
-</div>
-
 
 {% endblock content %}

--- a/app/templatetags/whatsnext.py
+++ b/app/templatetags/whatsnext.py
@@ -1,40 +1,28 @@
 import re
 
+from bson import ObjectId
 from bson.errors import InvalidId
 from django import template
 from mongoengine.errors import OperationError, ValidationError
 from pymongo.errors import PyMongoError
 
 from api.models import Project, Task
-from api.progress import compute_progress, next_actions
+from api.progress import compute_progress, cross_project_next, next_actions
 
 register = template.Library()
 
 HEX_COLOR = re.compile(r"^([0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$")
 FALLBACK_COLOR = "6b7280"
+TASK_SCAN_LIMIT = 10000
 
 
 def hex_color(color):
     return color if isinstance(color, str) and HEX_COLOR.match(color) else FALLBACK_COLOR
 
 
-@register.inclusion_tag("components/whatsnext.html")
-def whats_next(project_id):
-    try:
-        project = Project.objects.get(id=project_id)
-        statuses = [
-            {"id": status.id, "name": status.name, "color": status.color, "order": status.order}
-            for status in project.taskStatuses
-        ]
-        tasks = list(Task.objects.filter(projectID=project_id).only("name", "statusId", "priority", "parentTaskID"))
-    except (Project.DoesNotExist, ValidationError, InvalidId, OperationError, PyMongoError):
-        return {"available": False}
-
-    if not statuses:
-        return {"available": False}
-
+def task_records(tasks):
     parent_ids = {str(task.parentTaskID) for task in tasks if task.parentTaskID}
-    task_records = [
+    return [
         {
             "id": task.id,
             "name": task.name,
@@ -45,8 +33,29 @@ def whats_next(project_id):
         for task in tasks
     ]
 
-    progress = compute_progress(statuses, [record["status_id"] for record in task_records])
-    actions = next_actions(statuses, task_records)
+
+def status_records(statuses):
+    return [
+        {"id": status.id, "name": status.name, "color": status.color, "order": status.order}
+        for status in statuses
+    ]
+
+
+@register.inclusion_tag("components/whatsnext.html")
+def whats_next(project_id):
+    try:
+        project = Project.objects.get(id=project_id)
+        statuses = status_records(project.taskStatuses)
+        tasks = list(Task.objects.filter(projectID=project_id).only("name", "statusId", "priority", "parentTaskID"))
+    except (Project.DoesNotExist, ValidationError, InvalidId, OperationError, PyMongoError):
+        return {"available": False}
+
+    if not statuses:
+        return {"available": False}
+
+    records = task_records(tasks)
+    progress = compute_progress(statuses, [record["status_id"] for record in records])
+    actions = next_actions(statuses, records)
     segments = [
         {"name": segment["name"], "color": hex_color(segment["color"]), "count": segment["count"]}
         for segment in progress["segments"]
@@ -61,3 +70,40 @@ def whats_next(project_id):
         "in_flight": actions["in_flight"],
         "next_up": actions["next_up"],
     }
+
+
+@register.inclusion_tag("components/whatsnext_all.html")
+def whats_next_all(user_id):
+    if not user_id:
+        return {"available": False}
+
+    try:
+        owner = ObjectId(user_id)
+        projects = list(Project.objects.filter(userIDs=owner).only("name", "taskStatuses"))
+        project_ids = [project.id for project in projects]
+        if not project_ids:
+            return {"available": True, "projects": [], "more": 0}
+        tasks = list(
+            Task.objects.filter(projectID__in=project_ids)
+            .only("name", "statusId", "priority", "parentTaskID", "projectID")
+            .limit(TASK_SCAN_LIMIT)
+        )
+    except (ValidationError, InvalidId, OperationError, PyMongoError):
+        return {"available": False}
+
+    tasks_by_project = {}
+    for task in tasks:
+        tasks_by_project.setdefault(str(task.projectID), []).append(task)
+
+    project_records = [
+        {
+            "id": project.id,
+            "name": project.name,
+            "statuses": status_records(project.taskStatuses),
+            "tasks": task_records(tasks_by_project.get(str(project.id), [])),
+        }
+        for project in projects
+    ]
+
+    result = cross_project_next(project_records)
+    return {"available": True, "projects": result["projects"], "more": result["more"]}

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,6 +1,6 @@
 from bson import ObjectId
 
-from api.progress import compute_progress, next_actions
+from api.progress import compute_progress, cross_project_next, next_actions
 
 
 TODO = {"id": "s1", "name": "Todo", "color": "323232", "order": 1}
@@ -143,4 +143,54 @@ def test_unknown_or_missing_status_is_treated_as_todo():
     result = next_actions([TODO, DONE], tasks)
 
     assert {t["name"] for t in result["next_up"]} == {"Orphan", "Ghost"}
+
+
+def project(id, name, statuses, tasks):
+    return {"id": id, "name": name, "statuses": statuses, "tasks": tasks}
+
+
+def test_cross_project_excludes_empty_and_finished_projects():
+    active = project("p1", "Active", [TODO, DONE], [task("1", "Do it", "s1", priority=0)])
+    finished = project("p2", "Finished", [TODO, DONE], [task("2", "Old", "s3", priority=0)])
+    empty = project("p3", "Empty", [TODO, DONE], [])
+
+    result = cross_project_next([active, finished, empty])
+
+    assert [p["name"] for p in result["projects"]] == ["Active"]
+    assert result["projects"][0]["next_up"][0]["name"] == "Do it"
+
+
+def test_cross_project_orders_in_flight_projects_before_queued_only():
+    queued = project("p1", "Queued", [TODO, DONE], [task("1", "Start me", "s1", priority=0)])
+    moving = project("p2", "Moving", [TODO, DOING, DONE], [task("2", "In motion", "s2", priority=0)])
+
+    result = cross_project_next([queued, moving])
+
+    assert [p["name"] for p in result["projects"]] == ["Moving", "Queued"]
+
+
+def test_cross_project_caps_to_limit_and_reports_remainder():
+    projects = [
+        project(f"p{i}", f"P{i}", [TODO, DONE], [task(f"t{i}", f"Task {i}", "s1", priority=0)])
+        for i in range(10)
+    ]
+
+    result = cross_project_next(projects, limit=3)
+
+    assert len(result["projects"]) == 3
+    assert result["more"] == 7
+
+
+def test_cross_project_carries_project_identity_and_actions():
+    p = project("p9", "Duck", [TODO, DOING, DONE], [
+        task("a", "Building", "s2", priority=0),
+        task("b", "Queued task", "s1", priority=0),
+    ])
+
+    digest = cross_project_next([p])["projects"][0]
+
+    assert digest["id"] == "p9"
+    assert digest["name"] == "Duck"
+    assert [t["name"] for t in digest["in_flight"]] == ["Building"]
+    assert [t["name"] for t in digest["next_up"]] == ["Queued task"]
 


### PR DESCRIPTION
## What

The logged-in home page (`index.html`) now leads with a **cross-project "What's Next"**: one ranked list of work across all the user's projects, in flight and next-up, each task linked. This is the per-app analog of the cross-cutting readout, built from quayside's own task data (follows #58).

## How

- **`api/progress.py` — `cross_project_next(projects, limit=8)`**: runs the existing `next_actions` per project, drops finished/empty projects, ranks in-flight projects first (then most-active, then name), caps to `limit`, reports the remainder as `more`. Pure + tested.
- **`whats_next_all` tag**: per-user scoped (`Project.objects.filter(userIDs=ObjectId(user_id))`), two queries (projects + their tasks), groups tasks per project, fails safe to a hidden/empty state on bad input. Backstop `.limit()` on the task scan.
- **`status_records` / `task_records` helpers**: shared with the per-project card, no duplicated record-building.
- **`whatsnext_all.html` + `index.html`**: scrollable list, "+N more projects with open work".

## Tests

`cross_project_next`: excludes empty/finished projects, orders in-flight before queued-only, caps + remainder count, carries project identity/actions. 18 total in `tests/test_progress.py`.

## Reviewed

Adversarial review + fixes: explicit `ObjectId` coercion (no uncaught type error from a malformed token), empty-projects short-circuit (no empty `$in`), task-scan limit, helper ordering. Names HTML-escaped by Django autoescape; per-user scoping means this is tighter on authorization than the per-project card.

## Verified locally

Against Atlas with the real account (88 projects): home renders 8 project rows + "+70 more", task and project links resolve 200, per-project card unaffected.

## Deferred

- Unguarded `jwt.decode` in `context_processors.py` is a **pre-existing, site-wide** crash-on-bad-token; wants its own auth-hardening PR, not silent scope creep here.
- Scale beyond the task-scan limit would want a server-side aggregation pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)